### PR TITLE
fix(filtering): rare marshaling error and prevent more filtering errors

### DIFF
--- a/src/main/java/io/jenkins/plugins/restlistparam/logic/ValueResolver.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/logic/ValueResolver.java
@@ -112,7 +112,7 @@ public class ValueResolver {
       final Collection<String> resolved = JsonPath.parse(jsonStr).read(expression);
 
       if (!resolved.isEmpty()) {
-        container.setValue(resolved);
+        container.setValue(new ArrayList<>(resolved));
       }
       else {
         log.warning(Messages.RLP_ValueResolver_warn_jPath_NoValues());

--- a/src/main/resources/io/jenkins/plugins/restlistparam/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/Messages.properties
@@ -18,6 +18,8 @@ RLP.RestValueService.warn.OkHttpErr=OKHttp request threw {0}
 RLP.RestValueService.fine.UsingBasicAuth=Using Basic auth type to request REST-Values
 RLP.RestValueService.fine.UsingBearerAuth=Using Bearer auth type to request REST-Values
 RLP.RestValueService.warn.UnsupportedCredential=Attempted to use unsupported Credential type: {0}
+RLP.RestValueService.info.FilterReturnedNoValues=The filter `{0}` left no values to be displayed
+RLP.RestValueService.warn.FilterErr=Filtering value list threw a exception (see Jenkins log)
 # ValueResolver xPath logging Strings
 RLP.ValueResolver.warn.xPath.NoValues=xPath expression yielded no values
 RLP.ValueResolver.warn.xPath.ExpressionErr=Error in provided xPath expression


### PR DESCRIPTION
**Description**

This PR fixes a rare marshaling error that could occur when the filter method was not called and the plain JsonArray from the JsonPath value resolver got returned to vlaues.
Additionally this PR adds a bit more robust filtering logic with proper error propagation back to the user.

**Changes**

* fix for a rare marshaling error
* fix for some errors caused by filtering

**Issues**

* n/a