### PR TITLE
chore(repo): add Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 # Inherit base settings from https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.yml
 _extends: .github
-name-template: REST List Parameter $NEXT_PATCH_VERSION
+name-template: REST List Parameter v$NEXT_PATCH_VERSION
 tag-template: rest-list-parameter-$NEXT_PATCH_VERSION
 version-template: $MAJOR.$MINOR.$PATCH

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,5 @@
+# Inherit base settings from https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.yml
+_extends: .github
+name-template: REST List Parameter $NEXT_PATCH_VERSION
+tag-template: rest-list-parameter-$NEXT_PATCH_VERSION
+version-template: $MAJOR.$MINOR.$PATCH

--- a/.github/workflows/releaseDrafter.yml
+++ b/.github/workflows/releaseDrafter.yml
@@ -1,0 +1,54 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.ref, "refs/tags") }}
+    steps:
+      - name: Update Release Draft
+        uses: release-drafter/release-drafter@v5.11.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release_with_assets:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, "refs/tags") }}
+    steps:
+      - name: Publish Release Draft
+        id: publish_release
+        uses: release-drafter/release-drafter@v5.11.0
+        with:
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml -Dmaven.test.skip=true
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.publish_release.outputs.upload_url }}
+          asset_path: ./target/rest-list-parameter.hpi
+          asset_name: rest-list-parameter.hpi
+          asset_content_type: application/zip


### PR DESCRIPTION
**Description**

This PR adds Release Drafter to this repository, so that the change-log creation process is automated.
Additionally, a GitHub workflow for releasing said drafted releases is also included.

**Changes**

* add release drafter workflow to draft releases
* add release drafter workflow to publish releases

**Issues**

* possible error in workflow definition :thinking: (:crossed_fingers: all is good, since the JSON-schema validated successfully)