### PR TITLE
chore(docu): improve presence in plugin catalog

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -155,6 +155,13 @@ I prefer GitHub Issues over Jira Issues, but I check both regularly.
 
 For further contributing info please have a look at the JenkinsCI link:https://github.com/jenkinsci/.github/blob/master/CONTRIBUTING.md[contribution guidelines].
 
+[#licence]
+== Licence
+
+image::https://www.gnu.org/graphics/gplv3-or-later.svg[GPLv3 or later licence badge]
+
+Just if the badge from `shields.io` does not make it obvious enough, this project is licenced under the link:https://opensource.org/licenses/GPL-3.0[GPLv3] or later.
+
 [#development]
 == Development
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>4.10</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <properties>
@@ -53,9 +54,9 @@
 
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <scm>
-      <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-      <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-      <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin/blob/${project.artifactId}-${revision}/README.adoc</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,5 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-  Lets you specify a REST endpoint, that returns a Json or XML list of String values that can be picked from as a build parameter.<br />
-  The REST response can be parsed/selected via Json-Path or xPath and additionally filtered before presenting the values for selection.
+  A simple Jenkins parameter plugin that offers a list of values based on a REST call response.
 </div>


### PR DESCRIPTION
**Description**

This PR first and for most changes the URL property in the pom.xml to pinpoint the README.adoc file supposedly used by the plugin catalog page.
Additionally it updates the short description found in the plugin catalog page and adds an explicit section for the license in the readme. (in addition to already present `shileds.io` license badge)

**Changes**

* change pom `url` property to version pinned readme documentation
* change to shorten short description found in plugin catalog page
* add explicit section for License to readme (in addition to already present `shileds.io` license badge)

**Issues**

* N/A