### PR TITLE
fix(caching): odd caching behaviour with http chaching disabled 

### DIFF
--- a/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
@@ -140,21 +140,19 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
   }
 
   public List<String> getValues() {
-    if (values == null || values.isEmpty()) {
-      Optional<StandardCredentials> credentials = CredentialsUtils.findCredentials(credentialId);
+    Optional<StandardCredentials> credentials = CredentialsUtils.findCredentials(credentialId);
 
-      ResultContainer<List<String>> container = RestValueService.get(
-        getRestEndpoint(),
-        credentials.orElse(null),
-        getMimeType(),
-        getCacheTime(),
-        getValueExpression(),
-        getFilter(),
-        getValueOrder());
+    ResultContainer<List<String>> container = RestValueService.get(
+      getRestEndpoint(),
+      credentials.orElse(null),
+      getMimeType(),
+      getCacheTime(),
+      getValueExpression(),
+      getFilter(),
+      getValueOrder());
 
-      setErrorMsg(container.getErrorMsg().orElse(""));
-      values = container.getValue();
-    }
+    setErrorMsg(container.getErrorMsg().orElse(""));
+    values = container.getValue();
     return values;
   }
 
@@ -194,6 +192,7 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
     }
   }
 
+  @Override
   public boolean isValid(ParameterValue value) {
     return values.contains(((RestListParameterValue) value).getValue());
   }


### PR DESCRIPTION
### Description

I was made aware of an odd caching behavior the other day at work (we use this plugin there for some builds, but I develop this in my free time xD).
The issue was that http caching was disabled, yet the values still seemed cached as some recently added values where not loaded/shown. Based on this I investigated a bit and noticed that it most likely has something to do with the lifecycle the plugin class has once it gets created and me storing the retrieved values within the class (for validation proposes before creating the parameter value).
To fix this I opted to overwrite the values list each time a request to the `getValues` gets sent, as this *should* fix it.

### Changes

* fix odd caching with http caching turned off
* also adds missing `@Overwrite` for `isValid`

### Issues

* n/a