### PR TITLE
ci: general update and improvment

### DIFF
--- a/.github/workflows/upload-release-artifact.yml
+++ b/.github/workflows/upload-release-artifact.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - '*'
 
-env:
-  ARTIFACT_ID: rest-list-parameter
-
 jobs:
   build-upload-artifact:
     name: Build and upload artifact
@@ -40,24 +37,15 @@ jobs:
       - name: Build with Maven
         run: mvn -B package --file pom.xml -Dmaven.test.skip=true
 
-      - name: Set variables
-        id: set-variables
+      - name: Prepare GH Release Assets
         run: |
-          version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          asset_path="target/${ARTIFACT_ID}.hpi"
-          asset_name="${ARTIFACT_ID}-${version}.hpi"
-          echo "Version is ${version}"
-          echo "Asset_Path is ${asset_path}"
-          echo "Asset_Name is ${asset_name}"
-          echo "::set-output name=asset-path::${asset_path}"
-          echo "::set-output name=asset-name::${asset_name}"
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          cp target/rest-list-parameter.hpi rest-list-parameter-${VERSION}.hpi
+          sha256sum rest-list-parameter-${VERSION}.hpi > rest-list-parameter-${VERSION}.sha256sum
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Release Assets
+        uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ steps.release-drafter.outputs.upload_url }}
-          asset_path: ./${{ steps.set-variables.outputs.asset-path }}
-          asset_name: ${{ steps.set-variables.outputs.asset-name }}
-          asset_content_type: application/java-archive
+          asset_path: ./rest-list-parameter-${{ env.VERSION }}*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(useAci: true, configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
   [ platform: "linux", jdk: "8" ],
   [ platform: "linux", jdk: "11", javaLevel: "8" ]
 ])


### PR DESCRIPTION
### Description

This PR aims to migrate the Jenkins pipeline from the now *deprecated* `useAci` to  `useContainerAgent` and replaces the *deprecated* `actions/upload-release-asset` GitHub Action with a maintained alternative. 

### Changes

* migrate to `useContainerAgent`in Jenkinsfile
* update `Upload release artifact` to stop using deprecated `actions/upload-release-asset`
* add sha256sum to future GitHub release assets

### Issues

* n/a (just the deprecation notice by both affected components)