### PR TITLE
fix: failing re-build validation error after controller restarts

### DIFF
--- a/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
@@ -86,6 +86,35 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
     this.values = Collections.emptyList();
   }
 
+  private RestListParameterDefinition(final String name,
+                                      final String description,
+                                      final String restEndpoint,
+                                      final String credentialId,
+                                      final MimeType mimeType,
+                                      final String valueExpression,
+                                      final String displayExpression,
+                                      final ValueOrder valueOrder,
+                                      final String filter,
+                                      final Integer cacheTime,
+                                      final String defaultValue,
+                                      final List<ValueItem> values)
+  {
+    super(name, description);
+    this.restEndpoint = restEndpoint;
+    this.mimeType = mimeType;
+    this.valueExpression = valueExpression;
+    this.credentialId = StringUtils.isNotBlank(credentialId) ? credentialId : "";
+    if (mimeType == MimeType.APPLICATION_JSON) {
+      this.displayExpression = StringUtils.isNotBlank(displayExpression) ? displayExpression : "$";
+    }
+    this.defaultValue = StringUtils.isNotBlank(defaultValue) ? defaultValue : "";
+    this.valueOrder = valueOrder != null ? valueOrder : ValueOrder.NONE;
+    this.filter = StringUtils.isNotBlank(filter) ? filter : ".*";
+    this.cacheTime = cacheTime != null ? cacheTime : config.getCacheTime();
+    this.errorMsg = "";
+    this.values = values;
+  }
+
   public String getRestEndpoint() {
     return restEndpoint;
   }
@@ -183,7 +212,7 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
       return new RestListParameterDefinition(
         getName(), getDescription(), getRestEndpoint(), getCredentialId(), getMimeType(),
         getValueExpression(), getDisplayExpression(), getValueOrder(), getFilter(), getCacheTime(),
-        ValueResolver.parseDisplayValue(getMimeType(), value.getValue(), displayExpression));
+        ValueResolver.parseDisplayValue(getMimeType(), value.getValue(), displayExpression), getValues());
     }
     else {
       return this;


### PR DESCRIPTION
### Description

I the rare occasion that a re-build of a pipeline using this plugin occurred just after the Jenkins Controller was restated the value validation would always fail due to the copied parameter Definition class would have an empty list of values. (this solved itself once the Pipeline would be run once before triggering any re-build)

### Changes

* fix a edge-case bug for when the parameter would be part of a re-run job

### Issues

* n/a
* maybe #46 (but who knows as that had no proper description :man_shrugging:)