### PR TITLE
fix: doTestConfiguration failing due to default displayExpression

### DIFF
--- a/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
@@ -422,7 +422,7 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
         mimeType,
         0,
         valueExpression,
-        displayExpression,
+        StringUtils.isNotBlank(displayExpression) ? displayExpression : "$",
         filter,
         valueOrder);
 


### PR DESCRIPTION
### Description

This PR applies a temporary fix to `doTestConfiguration` as I don't want to set a default display value expression as long xml is still supported by the plugin.

### Changes

* apply temporary fix to `doTestConfiguration` when the 'default' display expr is send to it

### Issues

* n/a (due to unreleased yet)