### PR TITLE
fix: inefficient string equals use

### DIFF
--- a/src/main/java/io/jenkins/plugins/restlistparam/logic/ValueResolver.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/logic/ValueResolver.java
@@ -49,7 +49,7 @@ public class ValueResolver {
   {
     ResultContainer<List<ValueItem>> container = new ResultContainer<>(Collections.emptyList());
 
-    if (!displayExpression.equals("")) {
+    if (!displayExpression.isEmpty()) {
       log.warning(Messages.RLP_ValueResolver_warn_xPath_DisplayExpression());
     }
 


### PR DESCRIPTION
### Description

This PR fixes an inefficient use of String.equals() that snuck by.

### Changes

* change use pf String.equals("") to String.isEmpty()

### Issues

* n/a