### PR TITLE
fix: more serialisation hacks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -11,6 +11,6 @@ jobs:
     if: ${{ ! contains(github.event.head_commit.message, '[maven-release-plugin] prepare release') }}
     steps:
       - name: Update Release Draft
-        uses: release-drafter/release-drafter@v5.18.1
+        uses: release-drafter/release-drafter@v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upload-release-artifact.yml
+++ b/.github/workflows/upload-release-artifact.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update Release Draft
-        uses: release-drafter/release-drafter@v5.15.0
+        uses: release-drafter/release-drafter@v5.19.0
         id: release-drafter
         with:
           publish: true
@@ -19,10 +19,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.34</version>
+    <version>4.37</version>
     <relativePath />
   </parent>
 

--- a/src/main/java/io/jenkins/plugins/restlistparam/logic/ValueResolver.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/logic/ValueResolver.java
@@ -1,9 +1,6 @@
 package io.jenkins.plugins.restlistparam.logic;
 
-import com.jayway.jsonpath.InvalidJsonException;
-import com.jayway.jsonpath.InvalidPathException;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.*;
 import io.jenkins.plugins.restlistparam.Messages;
 import io.jenkins.plugins.restlistparam.model.MimeType;
 import io.jenkins.plugins.restlistparam.model.ResultContainer;
@@ -128,7 +125,7 @@ public class ValueResolver {
           resolved.stream()
                   .map(JsonPath::parse)
                   .map(context -> context.read("$"))
-                  .map(read -> (read instanceof Map) ? JsonPath.parse(read).jsonString() : (String) read)
+                  .map(ValueResolver::convertToString)
                   .map(value -> new ValueItem(value, parseDisplayValue(value, displayExpression)))
                   .collect(Collectors.toList())
         );
@@ -156,6 +153,24 @@ public class ValueResolver {
     }
 
     return container;
+  }
+
+  public static String convertToString(Object obj) {
+    if (obj instanceof Map) {
+      return JsonPath.parse(obj).jsonString();
+    }
+    else if (obj instanceof Integer) {
+      return Integer.toString((Integer) obj);
+    }
+    else if (obj instanceof Float) {
+      return Float.toString((Float) obj);
+    }
+    else if (obj instanceof String) {
+      return (String) obj;
+    }
+    else {
+      throw new ClassCastException("Unable to cast '" + obj.getClass().getCanonicalName() + "' to String");
+    }
   }
 
   /**


### PR DESCRIPTION
### Description

<!-- A brief description of this PR -->
This PR applies a hacky workaround for a serialisation issue that can occur if the JSON list of values to pars was not a Map (i.e. a child JSON object) or a String.
It also takes care of some straight forward dependency bumps.

### Changes

<!-- A list of changes within this PR -->
* apply "hacky" workaround for JSON serialisation issue if values are not strings 
* bump the plugin pom to 4.37
* bump various GHA to their latest version (Node16 runtime updates)

### Issues

* fixes #117