### PR TITLE
Replace git.io with expanded URLs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
         uses: github/codeql-action/autobuild@v1
 
       # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
+      # 📚 https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
       # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
       #    and modify them (or add more) to build your code if your project


### PR DESCRIPTION
### Description

https://github.blog/changelog/2022-04-25-git-io-deprecation/ announces end of life for the git.io service

jenkins-infra/update-center2#588

### Changes

Replace git.io references with their expansion

### Issues

N/A