### PR TITLE
feature: enable markup formatting in parameter description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
   </parent>
 
   <properties>
-    <revision>1.5.3</revision>
+    <revision>1.6.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.263.4</jenkins.version>
-    <bom.artifactId>2.263.x</bom.artifactId>
-    <bom.version>961.vf0c9f6f59827</bom.version>
+    <jenkins.version>2.332.1</jenkins.version>
+    <bom.artifactId>2.332.x</bom.artifactId>
+    <bom.version>1370.vfa_e23fe119c3</bom.version>
     <java.level>8</java.level>
     <!--
     Other properties you may want to use:
@@ -110,6 +110,15 @@
       <version>4.0.13-6</version>
     </dependency>
 
+    <!-- Optional Dependencies -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>antisamy-markup-formatter</artifactId>
+      <version>2.7</version>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Test Dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>

--- a/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/config.jelly
@@ -48,11 +48,18 @@
   </f:advanced>
 
   <f:validateButton
-      title="${%parameter.testConfig}" progress="${%parameter.testing}"
-      method="testConfiguration" with="restEndpoint,credentialId,mimeType,valueExpression,displayExpression,filter,valueOrder" />
+      title="${%parameter.testConfig}"
+      progress="${%parameter.testing}"
+      method="testConfiguration"
+      with="restEndpoint,credentialId,mimeType,valueExpression,displayExpression,filter,valueOrder"
+  />
 
   <f:entry title="${%parameter.description}" field="description">
-    <f:textarea />
+    <f:textarea
+      codemirror-mode="${app.markupFormatter.codeMirrorMode}"
+      codemirror-config="${app.markupFormatter.codeMirrorConfig}"
+      previewEndpoint="/markupFormatter/previewDescription"
+    />
   </f:entry>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/index.jelly
@@ -11,7 +11,8 @@
   <link rel="stylesheet" type="text/css" href="${resURL}/plugin/rest-list-parameter/css/select2-bootstrap4.min.css"/>
   <link rel="stylesheet" type="text/css" href="${resURL}/plugin/rest-list-parameter/css/select2-theming-patch.css"/>
 
-  <f:entry title="${it.name}" description="${it.description}">
+  <j:set var="escapeEntryTitleAndDescription" value="false"/>
+  <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
     <!-- this div is required because of ParametersDefinitionProperty.java#117 -->
     <div name="parameter" description="${it.description}">
       <input type="hidden" name="name" value="${it.name}"/>


### PR DESCRIPTION
### Description

This PR aims to enable markup support to the parameter description field.

### Changes

* update the plugin requirement to a more current LTS
* add markup support for parameter description

### Issues

* closes #129 