### PR TITLE
fix: refresh values list if empty on param value creation

### DIFF
--- a/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
@@ -223,12 +223,9 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
 
   @Override
   public ParameterValue createValue(final String value) {
-    if(values.isEmpty()) {
-      getValues();
-    }
-
     RestListParameterValue parameterValue = new RestListParameterValue(getName(), value, getDescription());
 
+    getValues();
     checkValue(parameterValue);
     return parameterValue;
   }
@@ -237,12 +234,9 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
   public ParameterValue createValue(final StaplerRequest req,
                                     final JSONObject jo)
   {
-    if(values.isEmpty()) {
-      getValues();
-    }
-
     RestListParameterValue value = req.bindJSON(RestListParameterValue.class, jo);
 
+    getValues();
     checkValue(value);
     return value;
   }

--- a/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
@@ -70,7 +70,8 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
                                      final Integer cacheTime,
                                      final String defaultValue)
   {
-    super(name, description);
+    super(name);
+    setDescription(description);
     this.restEndpoint = restEndpoint;
     this.mimeType = mimeType;
     this.valueExpression = valueExpression;
@@ -99,7 +100,8 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
                                       final String defaultValue,
                                       final List<ValueItem> values)
   {
-    super(name, description);
+    super(name);
+    setDescription(description);
     this.restEndpoint = restEndpoint;
     this.mimeType = mimeType;
     this.valueExpression = valueExpression;
@@ -221,6 +223,10 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
 
   @Override
   public ParameterValue createValue(final String value) {
+    if(values.isEmpty()) {
+      getValues();
+    }
+
     RestListParameterValue parameterValue = new RestListParameterValue(getName(), value, getDescription());
 
     checkValue(parameterValue);
@@ -231,6 +237,10 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
   public ParameterValue createValue(final StaplerRequest req,
                                     final JSONObject jo)
   {
+    if(values.isEmpty()) {
+      getValues();
+    }
+
     RestListParameterValue value = req.bindJSON(RestListParameterValue.class, jo);
 
     checkValue(value);


### PR DESCRIPTION
### Description

This PR aims to rectify a logic issue in this plugins code that was not taken into account when initially creating it.
Basically, other plugins such as the [Parameterized Scheduler](https://plugins.jenkins.io/parameterized-scheduler/) only call the `createValue` method and would run into issues unless the parameter where to be initialized first from a previous call. This is due to the values list currently only initializing and filling when `getValues` gets called (i.e. when attempting to trigger a new job with the parameter).

Is this an ideal solution? No, however, in lack of a better workaround this basically ensures that the valid values list is not empty when `createValue` gets called.

### Changes

* ensures there are values when attempting to create a ParameterValue and checking its validity

### Issues

* fixes #135 