### PR TITLE
Create a reversed sorting order

### DIFF
--- a/src/main/java/io/jenkins/plugins/restlistparam/logic/RestValueService.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/logic/RestValueService.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class RestValueService {
   private static final Logger log = Logger.getLogger(RestValueService.class.getName());
@@ -269,27 +270,24 @@ public class RestValueService {
     try {
       List<ValueItem> updatedValues;
 
-      if (isFilterSet(filter) && !isOrderSet(order)) {
-        updatedValues = values.stream()
-                              .filter(value -> value.getValue().matches(filter))
-                              .collect(Collectors.toList());
-      }
-      else if (!isFilterSet(filter) && isOrderSet(order)) {
-        updatedValues = values.stream()
-                              .sorted(order == ValueOrder.ASC ? Comparator.naturalOrder() : Comparator.reverseOrder())
-                              .collect(Collectors.toList());
-      }
-      else {
-        updatedValues = values.stream()
-                              .filter(value -> value.getValue().matches(filter))
-                              .sorted(order == ValueOrder.ASC ? Comparator.naturalOrder() : Comparator.reverseOrder())
-                              .collect(Collectors.toList());
+      Stream<ValueItem> valueStream = values.stream();
+      if (isFilterSet(filter)){
+        valueStream = valueStream.filter(value -> value.getValue().matches(filter));
       }
 
-      if (!updatedValues.isEmpty()) {
-        container.setValue(updatedValues);
+      if (order == ValueOrder.ASC) {
+        valueStream = valueStream.sorted(Comparator.naturalOrder());
+      } else if (order == ValueOrder.DSC) {
+        valueStream = valueStream.sorted(Comparator.reverseOrder());
       }
-      else {
+
+      updatedValues = valueStream.collect(Collectors.toList());
+      if (!updatedValues.isEmpty()) {
+        if (order == ValueOrder.REV){
+          Collections.reverse(updatedValues);
+        }
+        container.setValue(updatedValues);
+      } else {
         container.setErrorMsg(Messages.RLP_RestValueService_info_FilterReturnedNoValues(filter));
       }
     }

--- a/src/main/java/io/jenkins/plugins/restlistparam/model/ValueOrder.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/model/ValueOrder.java
@@ -3,7 +3,8 @@ package io.jenkins.plugins.restlistparam.model;
 public enum ValueOrder {
   NONE,
   ASC,
-  DSC;
+  DSC,
+  REV;
 
   @Override
   public String toString() {
@@ -14,6 +15,8 @@ public enum ValueOrder {
         return "Ascending";
       case DSC:
         return "Descending";
+      case REV:
+        return "Reversed";
       default:
         return "Undefined";
     }


### PR DESCRIPTION
### Description

When fetching the version from Nexus metadata, the versions are returned with ascending order. We would need to show it in descending order. The plugin doesn't allow to sort the versions in descending order correctly. because of the numeric sorting which is needing. The easiest solution was to implement a reverse sorting order.

### Changes

Added an extra reverse ordering option to sort.
