### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4136.vca_c3202a_7fd1</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -108,7 +108,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>okhttp-api</artifactId>
-      <version>4.11.0-183.va_87fc7a_89810</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -124,7 +123,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>antisamy-markup-formatter</artifactId>
-      <version>173.v680e3a_b_69ff3</version>
       <optional>true</optional>
     </dependency>
 

--- a/src/test/java/io/jenkins/plugins/restlistparam/RestValueServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/restlistparam/RestValueServiceTest.java
@@ -5,17 +5,22 @@ import io.jenkins.plugins.restlistparam.model.MimeType;
 import io.jenkins.plugins.restlistparam.model.ValueItem;
 import io.jenkins.plugins.restlistparam.model.ResultContainer;
 import io.jenkins.plugins.restlistparam.model.ValueOrder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 // Task for later: more unit tests here (preferably replace integration tests)
-public class RestValueServiceTest {
+class RestValueServiceTest {
+
   @Test
-  public void successfulGetIntegrationTest() {
+  void successfulGetIntegrationTest() {
     ResultContainer<List<ValueItem>> test = RestValueService
-      .get("http://api.github.com/repos/jellyfin/jellyfin/tags?per_page=3",
+      .get("https://api.github.com/repos/jellyfin/jellyfin/tags?per_page=3",
         null,
         MimeType.APPLICATION_JSON,
         0,
@@ -23,12 +28,12 @@ public class RestValueServiceTest {
         "$",
         null,
         ValueOrder.NONE);
-    Assert.assertFalse(test.getErrorMsg().isPresent());
-    Assert.assertEquals(3, test.getValue().size());
+    assertFalse(test.getErrorMsg().isPresent());
+    assertEquals(3, test.getValue().size());
   }
 
   @Test
-  public void unsuccessfulGetIntegrationTest() {
+  void unsuccessfulGetIntegrationTest() {
     ResultContainer<List<ValueItem>> test = RestValueService
       .get("https://gitlab.example.com/api/v4/projects/gitlab-org%2Fgitlab-runner/releases",
         null,
@@ -38,8 +43,8 @@ public class RestValueServiceTest {
         "$",
         null,
         ValueOrder.NONE);
-    Assert.assertNotNull(test);
-    Assert.assertTrue(test.getErrorMsg().isPresent());
-    Assert.assertEquals(0, test.getValue().size());
+    assertNotNull(test);
+    assertTrue(test.getErrorMsg().isPresent());
+    assertEquals(0, test.getValue().size());
   }
 }

--- a/src/test/java/io/jenkins/plugins/restlistparam/TestConst.java
+++ b/src/test/java/io/jenkins/plugins/restlistparam/TestConst.java
@@ -1,188 +1,203 @@
 package io.jenkins.plugins.restlistparam;
 
 public class TestConst {
-  public static final String validTestJson = "[\n" +
-    "  {\n" +
-    "    \"name\": \"v10.6.4\",\n" +
-    "    \"zipball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.4\",\n" +
-    "    \"tarball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.4\",\n" +
-    "    \"commit\": {\n" +
-    "      \"sha\": \"b49cd1d3017f23fc75703829ac2ea1d45d8a4881\",\n" +
-    "      \"url\": \"https://api.github.com/repos/jellyfin/jellyfin/commits/b49cd1d3017f23fc75703829ac2ea1d45d8a4881\"\n" +
-    "    },\n" +
-    "    \"node_id\": \"MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi40\"\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"name\": \"v10.6.3\",\n" +
-    "    \"zipball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.3\",\n" +
-    "    \"tarball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.3\",\n" +
-    "    \"commit\": {\n" +
-    "      \"sha\": \"16e3bd094f4c7c1b485ef164bf0a32267b7542c0\",\n" +
-    "      \"url\": \"https://api.github.com/repos/jellyfin/jellyfin/commits/16e3bd094f4c7c1b485ef164bf0a32267b7542c0\"\n" +
-    "    },\n" +
-    "    \"node_id\": \"MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4z\"\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"name\": \"v10.6.2\",\n" +
-    "    \"zipball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.2\",\n" +
-    "    \"tarball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.2\",\n" +
-    "    \"commit\": {\n" +
-    "      \"sha\": \"973fcdbaa11002b5d110bb45d09e7bf218bc3611\",\n" +
-    "      \"url\": \"https://api.github.com/repos/jellyfin/jellyfin/commits/973fcdbaa11002b5d110bb45d09e7bf218bc3611\"\n" +
-    "    },\n" +
-    "    \"node_id\": \"MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4y\"\n" +
-    "  }\n" +
-    "]\n";
+  public static final String validTestJson = """
+                                             [
+                                               {
+                                                 "name": "v10.6.4",
+                                                 "zipball_url": "https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.4",
+                                                 "tarball_url": "https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.4",
+                                                 "commit": {
+                                                   "sha": "b49cd1d3017f23fc75703829ac2ea1d45d8a4881",
+                                                   "url": "https://api.github.com/repos/jellyfin/jellyfin/commits/b49cd1d3017f23fc75703829ac2ea1d45d8a4881"
+                                                 },
+                                                 "node_id": "MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi40"
+                                               },
+                                               {
+                                                 "name": "v10.6.3",
+                                                 "zipball_url": "https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.3",
+                                                 "tarball_url": "https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.3",
+                                                 "commit": {
+                                                   "sha": "16e3bd094f4c7c1b485ef164bf0a32267b7542c0",
+                                                   "url": "https://api.github.com/repos/jellyfin/jellyfin/commits/16e3bd094f4c7c1b485ef164bf0a32267b7542c0"
+                                                 },
+                                                 "node_id": "MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4z"
+                                               },
+                                               {
+                                                 "name": "v10.6.2",
+                                                 "zipball_url": "https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.2",
+                                                 "tarball_url": "https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.2",
+                                                 "commit": {
+                                                   "sha": "973fcdbaa11002b5d110bb45d09e7bf218bc3611",
+                                                   "url": "https://api.github.com/repos/jellyfin/jellyfin/commits/973fcdbaa11002b5d110bb45d09e7bf218bc3611"
+                                                 },
+                                                 "node_id": "MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4y"
+                                               }
+                                             ]
+                                             """;
 
-  public static final String numberLikeTestJson = "[\n" +
-    "  {\n" +
-    "    \"name\": \"2024.19\",\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"name\": \"2024.20\",\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"name\": \"2024.0\",\n" +
-    "  }\n" +
-    "]\n";
+  public static final String numberLikeTestJson = """
+                                                  [
+                                                    {
+                                                      "name": "2024.19",
+                                                    },
+                                                    {
+                                                      "name": "2024.20",
+                                                    },
+                                                    {
+                                                      "name": "2024.0",
+                                                    }
+                                                  ]
+                                                  """;
 
-  public static final String numberValuesTestJson = "[\n" +
-    "  {\n" +
-    "    \"value\": 1.0\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"value\": 10\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"value\": 11.50\n" +
-    "  }\n" +
-    "]\n";
+  public static final String numberValuesTestJson = """
+                                                    [
+                                                      {
+                                                        "value": 1.0
+                                                      },
+                                                      {
+                                                        "value": 10
+                                                      },
+                                                      {
+                                                        "value": 11.50
+                                                      }
+                                                    ]
+                                                    """;
 
-  public static final String mixedTypeValuesTestJson = "[\n" +
-    "  {\n" +
-    "    \"value\": 1.0\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"value\": 10\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"value\": \"11.50\"\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"value\": true\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"value\": false\n" +
-    "  }\n" +
-    "]\n";
+  public static final String mixedTypeValuesTestJson = """
+                                                       [
+                                                         {
+                                                           "value": 1.0
+                                                         },
+                                                         {
+                                                           "value": 10
+                                                         },
+                                                         {
+                                                           "value": "11.50"
+                                                         },
+                                                         {
+                                                           "value": true
+                                                         },
+                                                         {
+                                                           "value": false
+                                                         }
+                                                       ]
+                                                       """;
 
-  public static final String validJsonValueItem = "{" +
-    "\"name\":\"v10.6.4\"," +
-    "\"zipball_url\":\"https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.4\"," +
-    "\"tarball_url\":\"https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.4\"," +
-    "\"commit\":{" +
-    "\"sha\":\"b49cd1d3017f23fc75703829ac2ea1d45d8a4881\"," +
-    "\"url\":\"https://api.github.com/repos/jellyfin/jellyfin/commits/b49cd1d3017f23fc75703829ac2ea1d45d8a4881\"" +
-    "}," +
-    "\"node_id\":\"MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi40\"" +
-    "}";
+  public static final String validJsonValueItem = """
+                                                  {
+                                                    "name": "v10.6.4",
+                                                    "zipball_url": "https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.4",
+                                                    "tarball_url": "https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.4",
+                                                    "commit": {
+                                                      "sha": "b49cd1d3017f23fc75703829ac2ea1d45d8a4881",
+                                                      "url": "https://api.github.com/repos/jellyfin/jellyfin/commits/b49cd1d3017f23fc75703829ac2ea1d45d8a4881"
+                                                    },
+                                                    "node_id": "MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi40"
+                                                 }
+                                                 """;
 
-  public static final String invalidTestJson = "[\n" +
-    "  {\n" +
-    "    \"name\": \"v10.6.4\",\n" +
-    "    \"zipball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.4\",\n" +
-    "    \"tarball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.4\",\n" +
-    "    \"commit\": {\n" +
-    "      \"sha\": \"b49cd1d3017f23fc75703829ac2ea1d45d8a4881\",\n" +
-    "      \"url\": \"https://api.github.com/repos/jellyfin/jellyfin/commits/b49cd1d3017f23fc75703829ac2ea1d45d8a4881\"\n" +
-    "    },\n" +
-    "    \"node_id\": \"MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi40\"\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"name\": \"v10.6.3\",\n" +
-    "    \"zipball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.3\",\n" +
-    "    \"tarball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.3\",\n" +
-    "    \"commit\": {\n" +
-    "      \"sha\": \"16e3bd094f4c7c1b485ef164bf0a32267b7542c0\",\n" +
-    "      \"url\": \"https://api.github.com/repos/jellyfin/jellyfin/commits/16e3bd094f4c7c1b485ef164bf0a32267b7542c0\"\n" +
-    "    },\n" +
-    "    \"node_id\": \"MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4z\"\n" +
-    "  },\n" +
-    "  {\n" +
-    "    \"name\": \"v10.6.2\",\n" +
-    "    \"zipball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.2\",\n" +
-    "    \"tarball_url\": \"https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.2\",\n" +
-    "    \"commit\": {\n" +
-    "      \"sha\": \"973fcdbaa11002b5d110bb45d09e7bf218bc3611\",\n" +
-    "      \"url\": \"https://api.github.com/repos/jellyfin/jellyfin/commits/973fcdbaa11002b5d110bb45d09e7bf218bc3611\"\n" +
-    "    },\n" +
-    "    \"node_id\": \"MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4y\"\n" +
-    "  }\n";
+  public static final String invalidTestJson = """
+                                               [
+                                                 {
+                                                   "name": "v10.6.4",
+                                                   "zipball_url": "https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.4",
+                                                   "tarball_url": "https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.4",
+                                                   "commit": {
+                                                     "sha": "b49cd1d3017f23fc75703829ac2ea1d45d8a4881",
+                                                     "url": "https://api.github.com/repos/jellyfin/jellyfin/commits/b49cd1d3017f23fc75703829ac2ea1d45d8a4881"
+                                                   },
+                                                   "node_id": "MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi40"
+                                                 },
+                                                 {
+                                                   "name": "v10.6.3",
+                                                   "zipball_url": "https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.3",
+                                                   "tarball_url": "https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.3",
+                                                   "commit": {
+                                                     "sha": "16e3bd094f4c7c1b485ef164bf0a32267b7542c0",
+                                                     "url": "https://api.github.com/repos/jellyfin/jellyfin/commits/16e3bd094f4c7c1b485ef164bf0a32267b7542c0"
+                                                   },
+                                                   "node_id": "MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4z"
+                                                 },
+                                                 {
+                                                   "name": "v10.6.2",
+                                                   "zipball_url": "https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.2",
+                                                   "tarball_url": "https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.2",
+                                                   "commit": {
+                                                     "sha": "973fcdbaa11002b5d110bb45d09e7bf218bc3611",
+                                                     "url": "https://api.github.com/repos/jellyfin/jellyfin/commits/973fcdbaa11002b5d110bb45d09e7bf218bc3611"
+                                                   },
+                                                   "node_id": "MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4y"
+                                                 }
+                                               """;
 
-  public static final String validTestXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" +
-    "<root>\n" +
-    "  <row>\n" +
-    "    <name>v10.6.4</name>\n" +
-    "    <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.4</zipball_url>\n" +
-    "    <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.4</tarball_url>\n" +
-    "    <commit>\n" +
-    "      <sha>b49cd1d3017f23fc75703829ac2ea1d45d8a4881</sha>\n" +
-    "      <url>https://api.github.com/repos/jellyfin/jellyfin/commits/b49cd1d3017f23fc75703829ac2ea1d45d8a4881</url>\n" +
-    "    </commit>\n" +
-    "    <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi40</node_id>\n" +
-    "  </row>\n" +
-    "  <row>\n" +
-    "    <name>v10.6.3</name>\n" +
-    "    <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.3</zipball_url>\n" +
-    "    <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.3</tarball_url>\n" +
-    "    <commit>\n" +
-    "      <sha>16e3bd094f4c7c1b485ef164bf0a32267b7542c0</sha>\n" +
-    "      <url>https://api.github.com/repos/jellyfin/jellyfin/commits/16e3bd094f4c7c1b485ef164bf0a32267b7542c0</url>\n" +
-    "    </commit>\n" +
-    "    <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4z</node_id>\n" +
-    "  </row>\n" +
-    "  <row>\n" +
-    "    <name>v10.6.2</name>\n" +
-    "    <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.2</zipball_url>\n" +
-    "    <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.2</tarball_url>\n" +
-    "    <commit>\n" +
-    "      <sha>973fcdbaa11002b5d110bb45d09e7bf218bc3611</sha>\n" +
-    "      <url>https://api.github.com/repos/jellyfin/jellyfin/commits/973fcdbaa11002b5d110bb45d09e7bf218bc3611</url>\n" +
-    "    </commit>\n" +
-    "    <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4y</node_id>\n" +
-    "  </row>\n" +
-    "</root>";
+  public static final String validTestXml = """
+                                            <?xml version="1.0" encoding="UTF-8" ?>
+                                            <root>
+                                              <row>
+                                                <name>v10.6.4</name>
+                                                <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.4</zipball_url>
+                                                <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.4</tarball_url>
+                                                <commit>
+                                                  <sha>b49cd1d3017f23fc75703829ac2ea1d45d8a4881</sha>
+                                                  <url>https://api.github.com/repos/jellyfin/jellyfin/commits/b49cd1d3017f23fc75703829ac2ea1d45d8a4881</url>
+                                                </commit>
+                                                <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi40</node_id>
+                                              </row>
+                                              <row>
+                                                <name>v10.6.3</name>
+                                                <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.3</zipball_url>
+                                                <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.3</tarball_url>
+                                                <commit>
+                                                  <sha>16e3bd094f4c7c1b485ef164bf0a32267b7542c0</sha>
+                                                  <url>https://api.github.com/repos/jellyfin/jellyfin/commits/16e3bd094f4c7c1b485ef164bf0a32267b7542c0</url>
+                                                </commit>
+                                                <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4z</node_id>
+                                              </row>
+                                              <row>
+                                                <name>v10.6.2</name>
+                                                <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.2</zipball_url>
+                                                <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.2</tarball_url>
+                                                <commit>
+                                                  <sha>973fcdbaa11002b5d110bb45d09e7bf218bc3611</sha>
+                                                  <url>https://api.github.com/repos/jellyfin/jellyfin/commits/973fcdbaa11002b5d110bb45d09e7bf218bc3611</url>
+                                                </commit>
+                                                <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4y</node_id>
+                                              </row>
+                                            </root>""";
 
-  public static final String invalidTestXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" +
-    "<root>\n" +
-    "  <row>\n" +
-    "    <name>v10.6.4</name>\n" +
-    "    <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.4</zipball_url>\n" +
-    "    <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.4</tarball_url>\n" +
-    "    <commit>\n" +
-    "      <sha>b49cd1d3017f23fc75703829ac2ea1d45d8a4881</sha>\n" +
-    "      <url>https://api.github.com/repos/jellyfin/jellyfin/commits/b49cd1d3017f23fc75703829ac2ea1d45d8a4881</url>\n" +
-    "    </commit>\n" +
-    "    <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi40</node_id>\n" +
-    "  </row>\n" +
-    "  <row>\n" +
-    "    <name>v10.6.3</name>\n" +
-    "    <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.3</zipball_url>\n" +
-    "    <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.3</tarball_url>\n" +
-    "    <commit>\n" +
-    "      <sha>16e3bd094f4c7c1b485ef164bf0a32267b7542c0</sha>\n" +
-    "      <url>https://api.github.com/repos/jellyfin/jellyfin/commits/16e3bd094f4c7c1b485ef164bf0a32267b7542c0</url>\n" +
-    "    </commit>\n" +
-    "    <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4z</node_id>\n" +
-    "  </row>\n" +
-    "  <row>\n" +
-    "    <name>v10.6.2</name>\n" +
-    "    <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.2</zipball_url>\n" +
-    "    <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.2</tarball_url>\n" +
-    "    <commit>\n" +
-    "      <sha>973fcdbaa11002b5d110bb45d09e7bf218bc3611</sha>\n" +
-    "      <url>https://api.github.com/repos/jellyfin/jellyfin/commits/973fcdbaa11002b5d110bb45d09e7bf218bc3611</url>\n" +
-    "    </commit>\n" +
-    "    <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4y</node_id>\n" +
-    "  </row>\n";
+  public static final String invalidTestXml = """
+                                              <?xml version="1.0" encoding="UTF-8" ?>
+                                              <root>
+                                                <row>
+                                                  <name>v10.6.4</name>
+                                                  <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.4</zipball_url>
+                                                  <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.4</tarball_url>
+                                                  <commit>
+                                                    <sha>b49cd1d3017f23fc75703829ac2ea1d45d8a4881</sha>
+                                                    <url>https://api.github.com/repos/jellyfin/jellyfin/commits/b49cd1d3017f23fc75703829ac2ea1d45d8a4881</url>
+                                                  </commit>
+                                                  <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi40</node_id>
+                                                </row>
+                                                <row>
+                                                  <name>v10.6.3</name>
+                                                  <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.3</zipball_url>
+                                                  <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.3</tarball_url>
+                                                  <commit>
+                                                    <sha>16e3bd094f4c7c1b485ef164bf0a32267b7542c0</sha>
+                                                    <url>https://api.github.com/repos/jellyfin/jellyfin/commits/16e3bd094f4c7c1b485ef164bf0a32267b7542c0</url>
+                                                  </commit>
+                                                  <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4z</node_id>
+                                                </row>
+                                                <row>
+                                                  <name>v10.6.2</name>
+                                                  <zipball_url>https://api.github.com/repos/jellyfin/jellyfin/zipball/v10.6.2</zipball_url>
+                                                  <tarball_url>https://api.github.com/repos/jellyfin/jellyfin/tarball/v10.6.2</tarball_url>
+                                                  <commit>
+                                                    <sha>973fcdbaa11002b5d110bb45d09e7bf218bc3611</sha>
+                                                    <url>https://api.github.com/repos/jellyfin/jellyfin/commits/973fcdbaa11002b5d110bb45d09e7bf218bc3611</url>
+                                                  </commit>
+                                                  <node_id>MDM6UmVmMTYxMDEyMDE5OnJlZnMvdGFncy92MTAuNi4y</node_id>
+                                                </row>
+                                              """;
 }

--- a/src/test/java/io/jenkins/plugins/restlistparam/ValueResolverTest.java
+++ b/src/test/java/io/jenkins/plugins/restlistparam/ValueResolverTest.java
@@ -5,153 +5,157 @@ import io.jenkins.plugins.restlistparam.logic.ValueResolver;
 import io.jenkins.plugins.restlistparam.model.MimeType;
 import io.jenkins.plugins.restlistparam.model.ResultContainer;
 import io.jenkins.plugins.restlistparam.model.ValueItem;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.List;
 
-public class ValueResolverTest {
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ValueResolverTest {
   // Json-Path Tests
   @Test
-  public void resolveJsonPathTest() {
+  void resolveJsonPathTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveJsonPath(TestConst.validTestJson, "$.*.name", "$");
-    Assert.assertNotNull(res);
-    Assert.assertFalse(res.getErrorMsg().isPresent());
-    Assert.assertEquals(3, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{"v10.6.4", "v10.6.3", "v10.6.2"},
+    assertNotNull(res);
+    assertFalse(res.getErrorMsg().isPresent());
+    assertEquals(3, res.getValue().size());
+    assertArrayEquals(new String[]{"v10.6.4", "v10.6.3", "v10.6.2"},
                              res.getValue().stream().map(ValueItem::getValue).toArray());
-    Assert.assertArrayEquals(new String[]{"v10.6.4", "v10.6.3", "v10.6.2"},
+    assertArrayEquals(new String[]{"v10.6.4", "v10.6.3", "v10.6.2"},
                              res.getValue().stream().map(ValueItem::getDisplayValue).toArray());
   }
 
   @Test
-  public void resolveJsonPathNumberLikeValuesTest() {
+  void resolveJsonPathNumberLikeValuesTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveJsonPath(TestConst.numberLikeTestJson, "$.*.name", "$");
-    Assert.assertNotNull(res);
-    Assert.assertFalse(res.getErrorMsg().isPresent());
-    Assert.assertEquals(3, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{"2024.19", "2024.20", "2024.0"},
+    assertNotNull(res);
+    assertFalse(res.getErrorMsg().isPresent());
+    assertEquals(3, res.getValue().size());
+    assertArrayEquals(new String[]{"2024.19", "2024.20", "2024.0"},
                              res.getValue().stream().map(ValueItem::getValue).toArray());
-    Assert.assertArrayEquals(new String[]{"2024.19", "2024.20", "2024.0"},
+    assertArrayEquals(new String[]{"2024.19", "2024.20", "2024.0"},
                              res.getValue().stream().map(ValueItem::getDisplayValue).toArray());
   }
 
   @Test
-  public void resolveJsonPathNumberValuesTest() {
+  void resolveJsonPathNumberValuesTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveJsonPath(TestConst.numberValuesTestJson, "$.*.value", "$");
-    Assert.assertNotNull(res);
-    Assert.assertFalse(res.getErrorMsg().isPresent());
-    Assert.assertEquals(3, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{"1.0", "10", "11.5"},
+    assertNotNull(res);
+    assertFalse(res.getErrorMsg().isPresent());
+    assertEquals(3, res.getValue().size());
+    assertArrayEquals(new String[]{"1.0", "10", "11.5"},
                              res.getValue().stream().map(ValueItem::getValue).toArray());
     // trailing 0 and decimal points are shaved off numbers by JSONStringer
-    Assert.assertArrayEquals(new String[]{"1", "10", "11.5"},
+    assertArrayEquals(new String[]{"1", "10", "11.5"},
                              res.getValue().stream().map(ValueItem::getDisplayValue).toArray());
   }
 
   @Test
-  public void resolveJsonPathMixedTypeValuesTest() {
+  void resolveJsonPathMixedTypeValuesTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveJsonPath(TestConst.mixedTypeValuesTestJson, "$.*.value", "$");
-    Assert.assertNotNull(res);
-    Assert.assertFalse(res.getErrorMsg().isPresent());
-    Assert.assertEquals(5, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{"1.0", "10", "11.50", "true", "false"},
+    assertNotNull(res);
+    assertFalse(res.getErrorMsg().isPresent());
+    assertEquals(5, res.getValue().size());
+    assertArrayEquals(new String[]{"1.0", "10", "11.50", "true", "false"},
                              res.getValue().stream().map(ValueItem::getValue).toArray());
     // trailing 0 and decimal points are shaved off numbers by JSONStringer
-    Assert.assertArrayEquals(new String[]{"1", "10", "11.50", "true", "false"},
+    assertArrayEquals(new String[]{"1", "10", "11.50", "true", "false"},
                              res.getValue().stream().map(ValueItem::getDisplayValue).toArray());
   }
 
   @Test
-  public void resolveJsonPathWithDifferentDisplayExpressionTest() {
+  void resolveJsonPathWithDifferentDisplayExpressionTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveJsonPath(TestConst.validTestJson, "$.*", "$.name");
-    Assert.assertNotNull(res);
-    Assert.assertFalse(res.getErrorMsg().isPresent());
-    Assert.assertEquals(3, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{"v10.6.4", "v10.6.3", "v10.6.2"},
+    assertNotNull(res);
+    assertFalse(res.getErrorMsg().isPresent());
+    assertEquals(3, res.getValue().size());
+    assertArrayEquals(new String[]{"v10.6.4", "v10.6.3", "v10.6.2"},
                              res.getValue().stream().map(ValueItem::getValue).map(JsonPath::parse).map(context -> context.read("$.name")).toArray());
-    Assert.assertArrayEquals(new String[]{"v10.6.4", "v10.6.3", "v10.6.2"},
+    assertArrayEquals(new String[]{"v10.6.4", "v10.6.3", "v10.6.2"},
                              res.getValue().stream().map(ValueItem::getDisplayValue).toArray());
   }
 
   @Test
-  public void emptyJsonPathResultsTest() {
+  void emptyJsonPathResultsTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveJsonPath("[]", "$.*", "$");
-    Assert.assertNotNull(res);
-    Assert.assertTrue(res.getErrorMsg().isPresent());
-    Assert.assertEquals(0, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
+    assertNotNull(res);
+    assertTrue(res.getErrorMsg().isPresent());
+    assertEquals(0, res.getValue().size());
+    assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
   }
 
   @Test
-  public void resolveJsonPathError1Test() {
+  void resolveJsonPathError1Test() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveJsonPath(TestConst.validTestJson, "$.", "$");
-    Assert.assertNotNull(res);
-    Assert.assertTrue(res.getErrorMsg().isPresent());
-    Assert.assertEquals(0, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
+    assertNotNull(res);
+    assertTrue(res.getErrorMsg().isPresent());
+    assertEquals(0, res.getValue().size());
+    assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
   }
 
   @Test
-  public void resolveJsonPathError2Test() {
+  void resolveJsonPathError2Test() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveJsonPath(TestConst.validTestJson, "$.name", "$");
-    Assert.assertNotNull(res);
-    Assert.assertTrue(res.getErrorMsg().isPresent());
-    Assert.assertEquals(0, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
+    assertNotNull(res);
+    assertTrue(res.getErrorMsg().isPresent());
+    assertEquals(0, res.getValue().size());
+    assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
   }
 
   @Test
-  public void invalidJsonErrorTest() {
+  void invalidJsonErrorTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveJsonPath(TestConst.invalidTestJson, "$.*.name", "$");
-    Assert.assertNotNull(res);
-    Assert.assertTrue(res.getErrorMsg().isPresent());
-    Assert.assertEquals(0, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
+    assertNotNull(res);
+    assertTrue(res.getErrorMsg().isPresent());
+    assertEquals(0, res.getValue().size());
+    assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
   }
 
   @Test
-  public void displayJsonValueFuncTest() {
+  void displayJsonValueFuncTest() {
     String displayValue = ValueResolver.parseDisplayValue(MimeType.APPLICATION_JSON, TestConst.validJsonValueItem, "$.name");
-    Assert.assertEquals("v10.6.4", displayValue);
+    assertEquals("v10.6.4", displayValue);
   }
 
   // xPath Tests
   @Test
-  public void resolveXPathTest() {
+  void resolveXPathTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveXPath(TestConst.validTestXml, "//row/name", "/");
-    Assert.assertNotNull(res);
-    Assert.assertFalse(res.getErrorMsg().isPresent());
-    Assert.assertEquals(3, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{"v10.6.4", "v10.6.3", "v10.6.2"},
+    assertNotNull(res);
+    assertFalse(res.getErrorMsg().isPresent());
+    assertEquals(3, res.getValue().size());
+    assertArrayEquals(new String[]{"v10.6.4", "v10.6.3", "v10.6.2"},
                              res.getValue().stream().map(ValueItem::getValue).toArray());
   }
 
   @Test
-  public void emptyXPathResultTest() {
+  void emptyXPathResultTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveXPath(TestConst.validTestXml, "//row_name", "/");
-    Assert.assertNotNull(res);
-    Assert.assertTrue(res.getErrorMsg().isPresent());
-    Assert.assertEquals(0, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
+    assertNotNull(res);
+    assertTrue(res.getErrorMsg().isPresent());
+    assertEquals(0, res.getValue().size());
+    assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
   }
 
   @Test
-  public void resolveXPathErrorTest() {
+  void resolveXPathErrorTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveXPath(TestConst.validTestXml, "\\row_name", "/");
-    Assert.assertNotNull(res);
-    Assert.assertTrue(res.getErrorMsg().isPresent());
-    Assert.assertEquals(0, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
+    assertNotNull(res);
+    assertTrue(res.getErrorMsg().isPresent());
+    assertEquals(0, res.getValue().size());
+    assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
   }
 
   @Test
-  public void invalidXMLErrorTest() {
+  void invalidXMLErrorTest() {
     ResultContainer<List<ValueItem>> res = ValueResolver.resolveXPath(TestConst.invalidTestXml, "//row/name", "/");
-    Assert.assertNotNull(res);
-    Assert.assertTrue(res.getErrorMsg().isPresent());
-    Assert.assertEquals(0, res.getValue().size());
-    Assert.assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
+    assertNotNull(res);
+    assertTrue(res.getErrorMsg().isPresent());
+    assertEquals(0, res.getValue().size());
+    assertArrayEquals(new String[]{}, res.getValue().stream().map(ValueItem::getValue).toArray());
   }
 }


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
