### PR TITLE
Remove unneeded jackson2 dependency and use json-api only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     -->
     <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
   </properties>
 
   <name>REST List Parameter</name>
@@ -92,8 +93,8 @@
       <artifactId>plain-credentials</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jackson2-api</artifactId>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>json-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
### Description

While doing Jackson3 migration I found that this plugin doesn't use jackson2 dependency

The <hpi.strictBundledArtifacts> confirm no transisitve dependency bundle Jackson2

### Changes

<!-- A list of changes within this PR -->

### Issues

<!-- A list of relevant issues to this PR -->