### PR TITLE
fix: avoid NPE when displayExpression is null

### DIFF
--- a/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
@@ -77,7 +77,7 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
     this.valueExpression = valueExpression;
     this.credentialId = credentialId != null && !credentialId.trim().isEmpty() ? credentialId : "";
     if (mimeType == MimeType.APPLICATION_JSON) {
-      this.displayExpression = !displayExpression.isBlank() ? displayExpression : "$";
+      this.displayExpression = displayExpression != null && !displayExpression.isBlank() ? displayExpression : "$";
     }
     this.defaultValue = defaultValue != null && !defaultValue.trim().isEmpty() ? defaultValue : "";
     this.valueOrder = valueOrder != null ? valueOrder : ValueOrder.NONE;
@@ -107,7 +107,7 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
     this.valueExpression = valueExpression;
     this.credentialId = credentialId != null && !credentialId.trim().isEmpty() ? credentialId : "";
     if (mimeType == MimeType.APPLICATION_JSON) {
-      this.displayExpression = !displayExpression.isBlank() ? displayExpression : "$";
+      this.displayExpression = displayExpression != null && !displayExpression.isBlank() ? displayExpression : "$";
     }
     this.defaultValue = defaultValue != null && !defaultValue.trim().isEmpty() ? defaultValue : "";
     this.valueOrder = valueOrder != null ? valueOrder : ValueOrder.NONE;
@@ -139,7 +139,7 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
 
   public String getDisplayExpression() {
     if (mimeType == MimeType.APPLICATION_JSON) {
-      return !displayExpression.isBlank() ? displayExpression : "$";
+      return displayExpression != null && !displayExpression.isBlank() ? displayExpression : "$";
     }
     return "";
   }

--- a/src/test/java/io/jenkins/plugins/restlistparam/RestListParameterDefinitionTest.java
+++ b/src/test/java/io/jenkins/plugins/restlistparam/RestListParameterDefinitionTest.java
@@ -1,0 +1,26 @@
+package io.jenkins.plugins.restlistparam;
+
+import io.jenkins.plugins.restlistparam.model.MimeType;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WithJenkins
+class RestListParameterDefinitionTest {
+
+  @Test
+  void nullDisplayExpressionDefaultsToRoot(JenkinsRule r) {
+    RestListParameterDefinition def = new RestListParameterDefinition(
+      "PARAM", "desc", "https://example.com/api", null, MimeType.APPLICATION_JSON, "$.tags", null);
+    assertEquals("$", def.getDisplayExpression());
+  }
+
+  @Test
+  void blankDisplayExpressionDefaultsToRoot(JenkinsRule r) {
+    RestListParameterDefinition def = new RestListParameterDefinition(
+      "PARAM", "desc", "https://example.com/api", null, MimeType.APPLICATION_JSON, "$.tags", "  ");
+    assertEquals("$", def.getDisplayExpression());
+  }
+}


### PR DESCRIPTION
### Description

The `displayExpression` argument can be null when a Declarative Pipeline omits it, which now throws `NullPointerException` in the constructor and `getDisplayExpression()` after the Commons Lang removal in #252. This restores the previous null-safe behaviour by defaulting to `$`.

### Changes

- Null-check `displayExpression` before calling `isBlank()` in both constructors and `getDisplayExpression()`
- Add regression test covering null and blank `displayExpression`

### Issues

Closes #255