### PR TITLE
[JENKINS-74375] Extract inline script from index.jelly for CSP compliance

### DIFF
--- a/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/index.jelly
@@ -6,6 +6,7 @@
 
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
   <st:adjunct includes="io.jenkins.plugins.select2"/>
+  <st:adjunct includes="io.jenkins.plugins.restlistparam.RestListParameterDefinition.index"/>
   <j:set var="id" value="${h.generateId()}"/>
 
   <link rel="stylesheet" type="text/css" href="${resURL}/plugin/rest-list-parameter/css/select2-bootstrap4.min.css"/>
@@ -18,7 +19,7 @@
       <input type="hidden" name="name" value="${it.name}"/>
       <input type="hidden" name="description" value="${it.description}"/>
 
-      <select id="${id}-select" class="setting-input" name="value">
+      <select id="${id}-select" data-select2-id="${id}-select" class="setting-input" name="value">
         <j:forEach var="item" items="${it.values}" varStatus="loop">
           <f:option value="${item.value}" selected="${item.displayValue.equals(it.defaultValue)}">
             ${item.displayValue}
@@ -50,15 +51,5 @@
       </tr>
     </j:when>
   </j:choose>
-
-  <script type="text/javascript">
-    jQuery3.noConflict();
-    jQuery3(document).ready(function () {
-      jQuery3("#${id}-select").select2({
-        placeholder: "Select an option",
-        theme: 'bootstrap4',
-      });
-    });
-  </script>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/index.js
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/index.js
@@ -1,0 +1,7 @@
+jQuery3.noConflict();
+jQuery3(document).ready(function () {
+  jQuery3("[data-select2-id]").select2({
+    placeholder: "Select an option",
+    theme: 'bootstrap4',
+  });
+});


### PR DESCRIPTION
## Summary

Extract inline `<script>` block from `index.jelly` into an external JavaScript file to comply with Jenkins Content Security Policy (CSP) requirements.

## Changes

1. Created `src/main/resources/.../RestListParameterDefinition/index.js` with the select2 initialization logic
2. Added `data-select2-id` attribute to the `<select>` element so the JS can locate it without inline Jelly expressions
3. Added `<st:adjunct>` reference to the external JS file
4. Removed the inline `<script>` block from `index.jelly`

## References

- Fixes #249
- See [Jenkins CSP documentation](https://www.jenkins.io/doc/developer/security/csp/#inline-javascript-blocks)