### PR TITLE
feat: support custom HTTP headers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,6 +31,7 @@ Release notes can be found in the link:https://github.com/jenkinsci/rest-list-pa
 
 * Specify any REST/Web endpoint that returns either a Json or XML response with values to select from for a build
 * Authenticate against the endpoint if required (either with `BASIC` or `BEARER` authentication)
+* Add custom HTTP headers to REST requests
 * Filter/Pars the values of the web response with Json-Path or xPath (depending on MIME type)
 * Set a per-selected default value (as long as that value is within the received value list)
 * User-friendly error communication
@@ -112,6 +113,43 @@ Depending on the authentication requirement for the REST/Web endpoint there are 
 
 IMPORTANT: The Authentication header will be build and added based on the type of the selected credential type.
 
+[#custom-headers]
+=== Custom HTTP headers
+
+Custom HTTP headers can be added from the parameter's advanced configuration.
+This is useful for APIs that require headers such as `X-API-Key`, `X-Auth-Token`, or a custom `Authorization` format that is not covered by the built-in Basic or Bearer authentication support.
+
+Each custom header entry supports:
+
+* `Header name` - for example `X-API-Key`, `X-Auth-Token`, or `Authorization`
+* `Static value` - stored by Jenkins as a `Secret`
+* `Secret Text credential` - recommended for API keys, tokens, and other sensitive values
+* `Value prefix` - optional text prepended to the static value or credential value, for example `Token `
+
+For sensitive header values, create a Jenkins credential of type `Secret text` and select it in the custom header row.
+This keeps tokens out of the job configuration and allows credentials to be rotated centrally.
+
+.Examples
+[cols="1,1,1"]
+|===
+|Header name |Credential / value |Resulting request header
+
+|`X-API-Key`
+|Secret Text credential `my-api-key`
+|`X-API-Key: ****`
+
+|`X-Auth-Token`
+|Secret Text credential `my-auth-token`
+|`X-Auth-Token: ****`
+
+|`Authorization`
+|Value prefix `CustomFormat ` plus Secret Text credential `custom-auth-token`
+|`Authorization: CustomFormat ****`
+|===
+
+Custom headers are applied after the default `Accept` header and the optional authentication header from `Credential ID`.
+If a custom `Authorization` header is configured, it overrides the default Basic or Bearer authentication header.
+
 [#validation]
 === Parameter Config Validation
 
@@ -171,7 +209,11 @@ pipeline {
       cacheTime: 10,    // optional
       defaultValue: '', // optional
       filter: '.*',     // optional
-      valueOrder: 'ASC' // optional
+      valueOrder: 'ASC', // optional
+      customHeaders: [   // optional
+        [name: 'X-API-Key', credentialId: 'example-api-key'],
+        [name: 'Authorization', credentialId: 'example-auth-token', valuePrefix: 'CustomFormat ']
+      ]
     )
   }
 

--- a/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/RestListParameterDefinition.java
@@ -11,6 +11,7 @@ import hudson.model.SimpleParameterDefinition;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.restlistparam.logic.RestValueService;
+import io.jenkins.plugins.restlistparam.model.CustomHeader;
 import io.jenkins.plugins.restlistparam.model.MimeType;
 import io.jenkins.plugins.restlistparam.model.ResultContainer;
 import io.jenkins.plugins.restlistparam.model.ValueOrder;
@@ -25,7 +26,9 @@ import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -46,6 +49,7 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
   private boolean enableValidation = true;
   private String errorMsg;
   private List<ValueItem> values;
+  private List<CustomHeader> customHeaders;
 
   @DataBoundConstructor
   public RestListParameterDefinition(final String name,
@@ -89,6 +93,7 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
     this.allowEmptyValue = allowEmptyValue;
     this.errorMsg = "";
     this.values = Collections.emptyList();
+    this.customHeaders = Collections.emptyList();
   }
 
   private RestListParameterDefinition(final String name,
@@ -104,7 +109,8 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
                                       final String defaultValue,
                                       final boolean allowEmptyValue,
                                       final boolean enableValidation,
-                                      final List<ValueItem> values)
+                                      final List<ValueItem> values,
+                                      final List<CustomHeader> customHeaders)
   {
     super(name);
     setDescription(description);
@@ -123,6 +129,7 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
     this.enableValidation = enableValidation;
     this.errorMsg = "";
     this.values = values;
+    this.customHeaders = customHeaders != null ? customHeaders : Collections.emptyList();
   }
 
   public String getRestEndpoint() {
@@ -207,6 +214,15 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
     this.enableValidation = enableValidation;
   }
 
+  public List<CustomHeader> getCustomHeaders() {
+    return customHeaders != null ? customHeaders : Collections.emptyList();
+  }
+
+  @DataBoundSetter
+  public void setCustomHeaders(final List<CustomHeader> customHeaders) {
+    this.customHeaders = customHeaders != null ? customHeaders : Collections.emptyList();
+  }
+
   void setErrorMsg(final String errorMsg) {
     this.errorMsg = errorMsg;
   }
@@ -232,7 +248,8 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
       getValueExpression(),
       getDisplayExpression(),
       getFilter(),
-      getValueOrder());
+      getValueOrder(),
+      resolveCustomHeaders(context));
 
     setErrorMsg(container.getErrorMsg().orElse(""));
     values = container.getValue();
@@ -247,7 +264,7 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
         getName(), getDescription(), getRestEndpoint(), getCredentialId(), getMimeType(),
         getValueExpression(), getDisplayExpression(), getValueOrder(), getFilter(), getCacheTime(),
         ValueResolver.parseDisplayValue(getMimeType(), value.getValue(), displayExpression),
-        isAllowEmptyValue(), isEnableValidation(), getValues());
+        isAllowEmptyValue(), isEnableValidation(), getValues(), getCustomHeaders());
     }
     else {
       return this;
@@ -343,6 +360,20 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
       return false;
     }
     return Objects.equals(defaultValue, other.defaultValue);
+  }
+
+  private Map<String, String> resolveCustomHeaders(final Item context) {
+    Map<String, String> headers = new LinkedHashMap<>();
+    for (CustomHeader customHeader : getCustomHeaders()) {
+      if (customHeader == null) {
+        continue;
+      }
+      String value = customHeader.resolve(context);
+      if (value != null) {
+        headers.put(customHeader.getName().trim(), value);
+      }
+    }
+    return headers;
   }
 
   @Symbol({"RESTList", "RestList", "RESTListParam"})
@@ -476,7 +507,8 @@ public final class RestListParameterDefinition extends SimpleParameterDefinition
         valueExpression,
         !displayExpression.isBlank() ? displayExpression : "$",
         filter,
-        valueOrder);
+        valueOrder,
+        Collections.emptyMap());
 
       Optional<String> errorMsg = container.getErrorMsg();
       List<ValueItem> values = container.getValue();

--- a/src/main/java/io/jenkins/plugins/restlistparam/logic/RestValueService.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/logic/RestValueService.java
@@ -60,8 +60,23 @@ public class RestValueService {
                                                      final String filter,
                                                      final ValueOrder order)
   {
+    return get(restEndpoint, credentials, mimeType, cacheTime, valueExpression, displayExpression, filter, order,
+      Collections.emptyMap());
+  }
+
+  public static ResultContainer<List<ValueItem>> get(final String restEndpoint,
+                                                     final StandardCredentials credentials,
+                                                     final MimeType mimeType,
+                                                     final Integer cacheTime,
+                                                     final String valueExpression,
+                                                     final String displayExpression,
+                                                     final String filter,
+                                                     final ValueOrder order,
+                                                     final Map<String, String> customHeaders)
+  {
     ResultContainer<List<ValueItem>> valueList = new ResultContainer<>(Collections.emptyList());
-    ResultContainer<String> rawValues = getValueStringFromRestEndpoint(restEndpoint, credentials, mimeType, cacheTime);
+    ResultContainer<String> rawValues = getValueStringFromRestEndpoint(restEndpoint, credentials, mimeType, cacheTime,
+      customHeaders);
     Optional<String> rawValueError = rawValues.getErrorMsg();
 
     if (!rawValueError.isPresent()) {
@@ -130,7 +145,8 @@ public class RestValueService {
   private static ResultContainer<String> getValueStringFromRestEndpoint(final String restEndpoint,
                                                                         final StandardCredentials credentials,
                                                                         final MimeType mimeType,
-                                                                        final Integer cacheTime)
+                                                                        final Integer cacheTime,
+                                                                        final Map<String, String> customHeaders)
   {
     ResultContainer<String> container = new ResultContainer<>("");
 
@@ -138,7 +154,7 @@ public class RestValueService {
     Request request = new Request.Builder()
       .url(restEndpoint)
       .cacheControl(OkHttpUtils.getCacheControl(cacheTime))
-      .headers(buildHeaders(credentials, mimeType))
+      .headers(buildHeaders(credentials, mimeType, customHeaders))
       .build();
 
     try (Response response = client.newCall(request).execute()) {
@@ -187,13 +203,29 @@ public class RestValueService {
    * @return OKHttp headers to be applied to the REST/Web request
    */
   private static Headers buildHeaders(final StandardCredentials credentials,
-                                      final MimeType mimeType)
+                                      final MimeType mimeType,
+                                      final Map<String, String> customHeaders)
   {
     Headers.Builder headBuilder = new Headers.Builder()
       .add(HTTPHeaders.ACCEPT, mimeType.getMime());
 
     if (credentials != null) {
       headBuilder.add(HTTPHeaders.AUTHORIZATION, buildAuthTypeWithCredential(credentials));
+    }
+
+    if (customHeaders != null) {
+      for (Map.Entry<String, String> header : customHeaders.entrySet()) {
+        if (header.getKey() != null && !header.getKey().trim().isEmpty()
+          && header.getValue() != null && !header.getValue().isEmpty())
+        {
+          try {
+            headBuilder.set(header.getKey().trim(), header.getValue());
+          }
+          catch (IllegalArgumentException ex) {
+            log.fine(Messages.RLP_RestValueService_fine_IgnoringInvalidCustomHeader(header.getKey()));
+          }
+        }
+      }
     }
 
     return headBuilder.build();

--- a/src/main/java/io/jenkins/plugins/restlistparam/model/CustomHeader.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/model/CustomHeader.java
@@ -34,7 +34,7 @@ public class CustomHeader extends AbstractDescribableImpl<CustomHeader> implemen
 
   @DataBoundConstructor
   public CustomHeader(final String name) {
-    this.name = name;
+    this.name = name != null ? name.trim() : null;
     this.credentialId = "";
     this.valuePrefix = "";
   }

--- a/src/main/java/io/jenkins/plugins/restlistparam/model/CustomHeader.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/model/CustomHeader.java
@@ -1,0 +1,160 @@
+package io.jenkins.plugins.restlistparam.model;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Item;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import io.jenkins.plugins.restlistparam.Messages;
+import io.jenkins.plugins.restlistparam.util.CredentialsUtils;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+
+public class CustomHeader extends AbstractDescribableImpl<CustomHeader> implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private static final String HEADER_NAME_PATTERN = "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$";
+
+  private final String name;
+  private Secret value;
+  private String credentialId;
+  private String valuePrefix;
+
+  @DataBoundConstructor
+  public CustomHeader(final String name) {
+    this.name = name;
+    this.credentialId = "";
+    this.valuePrefix = "";
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Secret getValue() {
+    return value;
+  }
+
+  @DataBoundSetter
+  public void setValue(final Secret value) {
+    this.value = value;
+  }
+
+  public String getCredentialId() {
+    return credentialId;
+  }
+
+  @DataBoundSetter
+  public void setCredentialId(final String credentialId) {
+    this.credentialId = credentialId != null && !credentialId.trim().isEmpty() ? credentialId : "";
+  }
+
+  public String getValuePrefix() {
+    return valuePrefix;
+  }
+
+  @DataBoundSetter
+  public void setValuePrefix(final String valuePrefix) {
+    this.valuePrefix = valuePrefix != null ? valuePrefix : "";
+  }
+
+  public String resolve(final Item context) {
+    if (!isValidName(name)) {
+      return null;
+    }
+
+    Optional<String> headerValue = resolveValue(context);
+    if (!headerValue.isPresent()) {
+      return null;
+    }
+
+    return getValuePrefix() + headerValue.get();
+  }
+
+  private Optional<String> resolveValue(final Item context) {
+    if (credentialId != null && !credentialId.isBlank()) {
+      Optional<StringCredentials> credentials = CredentialsUtils.findStringCredentials(context, credentialId);
+      return credentials.map(credential -> credential.getSecret().getPlainText())
+                        .filter(value -> !value.isEmpty());
+    }
+
+    String plainValue = Secret.toString(value);
+    if (plainValue == null || plainValue.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(plainValue);
+  }
+
+  public static boolean isValidName(final String name) {
+    return name != null && name.trim().matches(HEADER_NAME_PATTERN);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || this.getClass() != obj.getClass()) {
+      return false;
+    }
+    CustomHeader other = (CustomHeader) obj;
+    return Objects.equals(name, other.name)
+      && Objects.equals(value, other.value)
+      && Objects.equals(credentialId, other.credentialId)
+      && Objects.equals(valuePrefix, other.valuePrefix);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value, credentialId, valuePrefix);
+  }
+
+  @Extension
+  public static class DescriptorImpl extends Descriptor<CustomHeader> {
+    @Override
+    @Nonnull
+    public String getDisplayName() {
+      return Messages.RLP_CustomHeader_DisplayName();
+    }
+
+    @POST
+    public FormValidation doCheckName(@AncestorInPath final Item context,
+                                      @QueryParameter final String value)
+    {
+      if (context == null) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+      }
+      else {
+        context.checkPermission(Item.CONFIGURE);
+      }
+
+      if (value == null || value.trim().isEmpty()) {
+        return FormValidation.error(Messages.RLP_CustomHeader_ValidationErr_NameEmpty());
+      }
+      if (!isValidName(value)) {
+        return FormValidation.error(Messages.RLP_CustomHeader_ValidationErr_NameInvalid());
+      }
+      return FormValidation.ok();
+    }
+
+    @POST
+    public ListBoxModel doFillCredentialIdItems(@AncestorInPath final Item context,
+                                                @QueryParameter final String credentialId)
+    {
+      return CredentialsUtils.doFillStringCredentialsIdItems(context, credentialId);
+    }
+  }
+}

--- a/src/main/java/io/jenkins/plugins/restlistparam/util/CredentialsUtils.java
+++ b/src/main/java/io/jenkins/plugins/restlistparam/util/CredentialsUtils.java
@@ -54,6 +54,28 @@ public class CredentialsUtils {
       .includeCurrentValue(credentialsId);
   }
 
+  public static ListBoxModel doFillStringCredentialsIdItems(final Item context,
+                                                            final String credentialsId)
+  {
+    if ((context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER))
+      || (context != null
+      && !context.hasPermission(Item.EXTENDED_READ)
+      && !context.hasPermission(CredentialsProvider.USE_ITEM)))
+    {
+      log.info(Messages.RLP_CredentialsUtils_info_NoPermission());
+      return new StandardListBoxModel().includeCurrentValue(credentialsId);
+    }
+    return new StandardListBoxModel()
+      .includeEmptyValue()
+      .includeMatchingAs(
+        context instanceof Queue.Task ? Tasks.getAuthenticationOf((Queue.Task) context) : ACL.SYSTEM,
+        context,
+        StringCredentials.class,
+        Collections.emptyList(),
+        CredentialsMatchers.instanceOf(StringCredentials.class))
+      .includeCurrentValue(credentialsId);
+  }
+
   public static FormValidation doCheckCredentialsId(final Item context,
                                                     final String credentialsId)
   {
@@ -94,5 +116,22 @@ public class CredentialsUtils {
         CredentialsMatchers.instanceOf(StringCredentials.class),
         CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class)));
     return Optional.ofNullable(CredentialsMatchers.firstOrNull(lookupCredentials, allOf));
+  }
+
+  public static Optional<StringCredentials> findStringCredentials(final Item context,
+                                                                  final String credentialsId)
+  {
+    if (credentialsId == null || credentialsId.isBlank()) {
+      return Optional.empty();
+    }
+    List<StringCredentials> lookupCredentials = CredentialsProvider.lookupCredentials(
+      StringCredentials.class,
+      context,
+      context instanceof Queue.Task ? Tasks.getAuthenticationOf((Queue.Task)context) : ACL.SYSTEM,
+      Collections.emptyList());
+    CredentialsMatcher matcher = CredentialsMatchers.allOf(
+      CredentialsMatchers.withId(credentialsId),
+      CredentialsMatchers.instanceOf(StringCredentials.class));
+    return Optional.ofNullable(CredentialsMatchers.firstOrNull(lookupCredentials, matcher));
   }
 }

--- a/src/main/resources/io/jenkins/plugins/restlistparam/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/Messages.properties
@@ -7,6 +7,9 @@ RLP.DescriptorImpl.ValidationErr.UnknownMime=Unknown MimeType
 RLP.DescriptorImpl.ValidationErr.CacheTime=The time to cache for MUST BE positive or 0
 RLP.DescriptorImpl.ValidationOk.ConfigValid=Test Successful! {0} Values, first: {1}
 RLP.Definition.ValueException=Illegal value for parameter {0}: {1}
+RLP.CustomHeader.DisplayName=Custom HTTP Header
+RLP.CustomHeader.ValidationErr.NameEmpty=Header name must not be empty
+RLP.CustomHeader.ValidationErr.NameInvalid=Header name contains invalid characters
 # Global Configuration validation Strings
 RLP.GlobalConfig.ValidationErr.CacheSize=The cache size MUST BE greater than 0 MiB
 RLP.GlobalConfig.ValidationErr.CacheTime=The cache time MUST BE greater or equal 0 Minutes
@@ -26,6 +29,7 @@ RLP.RestValueService.warn.UnknownHost=Unknown Host: {0}
 RLP.RestValueService.warn.OkHttpErr=OKHttp request threw {0}
 RLP.RestValueService.fine.UsingBasicAuth=Using Basic auth type to request REST-Values
 RLP.RestValueService.fine.UsingBearerAuth=Using Bearer auth type to request REST-Values
+RLP.RestValueService.fine.IgnoringInvalidCustomHeader=Ignoring invalid custom header: {0}
 RLP.RestValueService.warn.UnsupportedCredential=Attempted to use unsupported Credential type: {0}
 RLP.RestValueService.info.FilterReturnedNoValues=The filter `{0}` left no values to be displayed
 RLP.RestValueService.warn.FilterErr=Filtering value list threw {0}

--- a/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/config.jelly
@@ -52,6 +52,10 @@
       <f:entry title="${%parameter.enableValidation}" field="enableValidation">
         <f:checkbox default="true" />
       </f:entry>
+
+      <f:entry title="${%parameter.customHeaders}" field="customHeaders">
+        <f:repeatableProperty field="customHeaders" add="${%parameter.customHeaders.add}" />
+      </f:entry>
     </f:section>
   </f:advanced>
 

--- a/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/config.properties
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/config.properties
@@ -12,5 +12,7 @@ parameter.applySortOrder=Apply Sort Order
 parameter.defaultValue=Default Value
 parameter.allowEmptyValue=Allow Empty Value
 parameter.enableValidation=Enable Value Validation
+parameter.customHeaders=Custom HTTP Headers
+parameter.customHeaders.add=Add Header
 parameter.testConfig=Test Configuration
 parameter.testing=Test running ...

--- a/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/help-customHeaders.html
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/RestListParameterDefinition/help-customHeaders.html
@@ -1,0 +1,5 @@
+<div>
+  Optional HTTP headers to add to REST requests. Header values can come from a stored secret value or from a Jenkins
+  Secret text credential. Custom headers are applied after the default headers, so a custom header with the same name
+  replaces the default value.
+</div>

--- a/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/config.jelly
@@ -1,0 +1,18 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+  <f:entry title="${%customHeader.name}" field="name">
+    <f:textbox checkMethod="post" />
+  </f:entry>
+
+  <f:entry title="${%customHeader.value}" field="value">
+    <f:password />
+  </f:entry>
+
+  <f:entry title="${%customHeader.credentialId}" field="credentialId">
+    <c:select style="min-width: 18rem;" />
+  </f:entry>
+
+  <f:entry title="${%customHeader.valuePrefix}" field="valuePrefix">
+    <f:textbox />
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/config.properties
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/config.properties
@@ -1,0 +1,4 @@
+customHeader.name=Header Name
+customHeader.value=Static Value
+customHeader.credentialId=Secret Text Credential
+customHeader.valuePrefix=Value Prefix

--- a/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/help-credentialId.html
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/help-credentialId.html
@@ -1,0 +1,4 @@
+<div>
+  Optional Jenkins Secret text credential used as the header value. When selected, this credential takes precedence over
+  the static value.
+</div>

--- a/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/help-name.html
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/help-name.html
@@ -1,0 +1,3 @@
+<div>
+  HTTP header name, such as <code>X-API-Key</code>, <code>X-Auth-Token</code>, or <code>Authorization</code>.
+</div>

--- a/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/help-value.html
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/help-value.html
@@ -1,0 +1,3 @@
+<div>
+  Static header value stored encrypted by Jenkins. Leave empty when using a Secret text credential.
+</div>

--- a/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/help-valuePrefix.html
+++ b/src/main/resources/io/jenkins/plugins/restlistparam/model/CustomHeader/help-valuePrefix.html
@@ -1,0 +1,3 @@
+<div>
+  Optional text prepended to the resolved value, for example <code>Bearer </code> or <code>Token </code>.
+</div>

--- a/src/test/java/io/jenkins/plugins/restlistparam/RestListParameterDefinitionJenkinsTest.java
+++ b/src/test/java/io/jenkins/plugins/restlistparam/RestListParameterDefinitionJenkinsTest.java
@@ -1,19 +1,35 @@
 package io.jenkins.plugins.restlistparam;
 
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 import hudson.model.Descriptor;
 import hudson.model.ParameterDefinition;
 import hudson.model.StringParameterValue;
+import hudson.util.Secret;
+import io.jenkins.plugins.restlistparam.model.CustomHeader;
 import io.jenkins.plugins.restlistparam.model.MimeType;
 import io.jenkins.plugins.restlistparam.model.ValueOrder;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.jenkinsci.plugins.structs.SymbolLookup;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -181,5 +197,108 @@ class RestListParameterDefinitionJenkinsTest {
 
     RestListParameterDefinition def = model.instantiate(args);
     assertFalse(def.isEnableValidation(), "enableValidation DataBoundSetter not applied");
+  }
+
+  @Test
+  void pipelineDslAcceptsCustomHeaders(JenkinsRule r) throws Exception {
+    DescribableModel<RestListParameterDefinition> model = new DescribableModel<>(RestListParameterDefinition.class);
+    Map<String, Object> args = new HashMap<>();
+    args.put("name", "VERSION");
+    args.put("description", "pick a version");
+    args.put("restEndpoint", "http://127.0.0.1:1/none");
+    args.put("credentialId", "");
+    args.put("mimeType", "APPLICATION_JSON");
+    args.put("valueExpression", "$.tags");
+    args.put("displayExpression", "$");
+
+    Map<String, Object> authHeader = new HashMap<>();
+    authHeader.put("name", "Authorization");
+    authHeader.put("credentialId", "svc_netbox_prd");
+    authHeader.put("valuePrefix", "Token ");
+    args.put("customHeaders", Arrays.asList(authHeader));
+
+    RestListParameterDefinition def = model.instantiate(args);
+    List<CustomHeader> customHeaders = def.getCustomHeaders();
+    assertEquals(1, customHeaders.size());
+    assertEquals("Authorization", customHeaders.get(0).getName());
+    assertEquals("svc_netbox_prd", customHeaders.get(0).getCredentialId());
+    assertEquals("Token ", customHeaders.get(0).getValuePrefix());
+  }
+
+  @Test
+  void secretTextCredentialFeedsCustomHeader(JenkinsRule r) throws Exception {
+    SystemCredentialsProvider.getInstance().getCredentials().add(
+      new StringCredentialsImpl(CredentialsScope.GLOBAL, "custom-token", "custom token",
+        Secret.fromString("credential-token")));
+    SystemCredentialsProvider.getInstance().save();
+
+    try (HeaderCaptureServer server = new HeaderCaptureServer()) {
+      RestListParameterDefinition def = new RestListParameterDefinition(
+        "p", "d", server.url(), "", MimeType.APPLICATION_JSON, "$.*.name", "$",
+        ValueOrder.NONE, ".*", 0, "", false);
+      CustomHeader header = new CustomHeader("X-Auth-Token");
+      header.setCredentialId("custom-token");
+      header.setValuePrefix("Token ");
+      def.setCustomHeaders(Collections.singletonList(header));
+
+      assertEquals(3, def.getValues().size());
+      assertEquals("Token credential-token", server.header("X-Auth-Token"));
+    }
+  }
+
+  @Test
+  void definitionWithCustomHeadersIsSerializable(JenkinsRule r) throws Exception {
+    RestListParameterDefinition def = new RestListParameterDefinition(
+      "p", "d", "http://127.0.0.1:1/none", "", MimeType.APPLICATION_JSON, "$.*.name", "$",
+      ValueOrder.NONE, ".*", 0, "", false);
+    CustomHeader header = new CustomHeader("Authorization");
+    header.setCredentialId("custom-token");
+    header.setValuePrefix("Token ");
+    def.setCustomHeaders(Collections.singletonList(header));
+
+    try (ObjectOutputStream out = new ObjectOutputStream(new ByteArrayOutputStream())) {
+      out.writeObject(def);
+    }
+  }
+
+  @Test
+  void customHeadersDefaultToEmpty(JenkinsRule r) {
+    RestListParameterDefinition def = new RestListParameterDefinition(
+      "p", "d", "https://example.invalid", "", MimeType.APPLICATION_JSON, "$.*", "$");
+    assertTrue(def.getCustomHeaders().isEmpty());
+  }
+
+  private static class HeaderCaptureServer implements AutoCloseable {
+    private final HttpServer server;
+    private final AtomicReference<com.sun.net.httpserver.Headers> lastHeaders = new AtomicReference<>();
+
+    HeaderCaptureServer() throws IOException {
+      server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+      server.createContext("/", this::respond);
+      server.start();
+    }
+
+    String url() {
+      return "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+    }
+
+    String header(final String name) {
+      com.sun.net.httpserver.Headers headers = lastHeaders.get();
+      return headers != null ? headers.getFirst(name) : null;
+    }
+
+    private void respond(final HttpExchange exchange) throws IOException {
+      lastHeaders.set(exchange.getRequestHeaders());
+      byte[] response = TestConst.validTestJson.getBytes(StandardCharsets.UTF_8);
+      exchange.getResponseHeaders().set("Content-Type", "application/json");
+      exchange.sendResponseHeaders(200, response.length);
+      exchange.getResponseBody().write(response);
+      exchange.close();
+    }
+
+    @Override
+    public void close() {
+      server.stop(0);
+    }
   }
 }

--- a/src/test/java/io/jenkins/plugins/restlistparam/RestValueServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/restlistparam/RestValueServiceTest.java
@@ -1,7 +1,9 @@
 package io.jenkins.plugins.restlistparam;
 
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import hudson.util.Secret;
 import io.jenkins.plugins.restlistparam.logic.RestValueService;
+import io.jenkins.plugins.restlistparam.model.CustomHeader;
 import io.jenkins.plugins.restlistparam.model.MimeType;
 import io.jenkins.plugins.restlistparam.model.ValueItem;
 import io.jenkins.plugins.restlistparam.model.ResultContainer;
@@ -62,5 +64,14 @@ class RestValueServiceTest {
       Map.of("X-API-Key", "static-token"));
 
     assertEquals("static-token", headers.get("X-API-Key"));
+  }
+
+  @Test
+  void trimsCustomHeaderNameOnConstruction() {
+    CustomHeader header = new CustomHeader("Authorization ");
+    header.setValue(Secret.fromString("token"));
+
+    assertEquals("Authorization", header.getName());
+    assertEquals("token", header.resolve(null));
   }
 }

--- a/src/test/java/io/jenkins/plugins/restlistparam/RestValueServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/restlistparam/RestValueServiceTest.java
@@ -1,13 +1,17 @@
 package io.jenkins.plugins.restlistparam;
 
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import io.jenkins.plugins.restlistparam.logic.RestValueService;
 import io.jenkins.plugins.restlistparam.model.MimeType;
 import io.jenkins.plugins.restlistparam.model.ValueItem;
 import io.jenkins.plugins.restlistparam.model.ResultContainer;
 import io.jenkins.plugins.restlistparam.model.ValueOrder;
+import okhttp3.Headers;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -46,5 +50,17 @@ class RestValueServiceTest {
     assertNotNull(test);
     assertTrue(test.getErrorMsg().isPresent());
     assertEquals(0, test.getValue().size());
+  }
+
+  @Test
+  void sendsCustomHeader() throws Exception {
+    Method buildHeaders = RestValueService.class.getDeclaredMethod("buildHeaders",
+      StandardCredentials.class, MimeType.class, Map.class);
+    buildHeaders.setAccessible(true);
+
+    Headers headers = (Headers) buildHeaders.invoke(null, null, MimeType.APPLICATION_JSON,
+      Map.of("X-API-Key", "static-token"));
+
+    assertEquals("static-token", headers.get("X-API-Key"));
   }
 }


### PR DESCRIPTION
Refs: https://github.com/jenkinsci/rest-list-parameter-plugin/issues/261

### Description

Adds support for custom HTTP headers on REST List parameters, allowing users to call APIs that require headers such as `X-API-Key`, `X-Auth-Token`, or custom `Authorization` formats.

### Changes

- Added configurable custom HTTP headers in the parameter advanced configuration
- Added support for static secret values and Jenkins Secret Text credentials
- Added optional value prefixes for headers, e.g. `Token `
- Applied custom headers to REST requests, including overriding the default `Authorization` header when configured
- Added validation for custom header names
- Updated Pipeline DSL examples and README documentation
- Added unit and Jenkins tests for custom headers, credential resolution, serialization, and Pipeline DSL support

### Issues

https://github.com/jenkinsci/rest-list-parameter-plugin/issues/261